### PR TITLE
Simple sorting with simple tests.

### DIFF
--- a/examples/test_sort.bib
+++ b/examples/test_sort.bib
@@ -1,0 +1,93 @@
+% Encoding: UTF-8
+
+@Misc{SaA3a2010,
+  author = {Salt Water},
+  title  = {A3a},
+  year   = {2010},
+}
+
+@Book{1998BBbA2a,
+  author    = {Bron Would and Bronn Wouldnot},
+  publisher = {G},
+  title     = {A2a},
+  year      = {1997},
+  month     = {02},
+}
+
+@Book{1998BBaA1a,
+  author    = {Bron Would and Bronn Wouldnot},
+  publisher = {G},
+  title     = {A1a},
+  year      = {1997},
+  month     = {05},
+}
+
+@Article{2018DJaMae,
+  author    = {Dohn Doe and John Doe},
+  journal   = {Sci},
+  title     = {Mae},
+  year      = {2018},
+  month     = {01},
+  volume    = {4},
+  publisher = {E},
+}
+
+@Article{2018DJaMad,
+  author    = {Hohn Doe and John Doe},
+  journal   = {Sci},
+  title     = {Mad},
+  year      = {2018},
+  month     = {05},
+  volume    = {3},
+  publisher = {E},
+}
+
+@Unpublished{2007JJaAbe,
+  author    = {John Cow and Jane Doe},
+  note      = {Preprint},
+  title     = {Abe},
+  month     = {01},
+  year      = {2007},
+  publisher = {B},
+}
+
+@Unpublished{2007JJbAbe,
+  author    = {John Bow and Jane Doe},
+  note      = {Preprint},
+  title     = {Abe},
+  month     = {01},
+  year      = {2007},
+  publisher = {B},
+}
+
+@Article{2010JJBaAaa,
+  author    = {John Doe and Jane Doe and Bronn Would},
+  journal   = {A},
+  title     = {Aaa},
+  year      = {2010},
+  month     = {8},
+  volume    = {1},
+  publisher = {A},
+}
+
+@Article{2010JJBbAaa,
+  author    = {John Doe and Jane Doe and Bronn Not Would},
+  journal   = {A},
+  title     = {Aaa},
+  year      = {2010},
+  month     = {08},
+  volume    = {1},
+  publisher = {A},
+}
+
+@Article{2011JJBcAaa,
+  author    = {John Doe and Jane Doe},
+  journal   = {A},
+  title     = {Aaa},
+  year      = {2011},
+  month     = {8},
+  volume    = {1},
+  publisher = {A},
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/src/Bibliography.jl
+++ b/src/Bibliography.jl
@@ -14,8 +14,10 @@ import DataStructures.OrderedSet
 export export_bibtex, import_bibtex
 export export_web, bibtex_to_web
 export select
+export sort_bibliography!
 
 include("select.jl")
+include("sort_bibliography.jl")
 include("bibtex.jl")
 include("csl.jl")
 include("staticweb.jl")

--- a/src/sort_bibliography.jl
+++ b/src/sort_bibliography.jl
@@ -1,0 +1,83 @@
+"""
+    const sorting_rules = Dict{Symbol, Vector{Symbol}}(
+        :nty  => [:authors;:editors;:title;:date],
+        :nyt  => [:authors;:editors;:date;:title]
+    );
+
+Implemented sorting rules for bibliography entry sorting.
+
+See also [`sort_bibliography!`](@ref).
+"""
+const sorting_rules = Dict{Symbol, Vector{Symbol}}(
+    :nty  => [:authors;:editors;:title;:date],
+    :nyt  => [:authors;:editors;:date;:title]
+);
+
+"""
+    sort_bibliography!(
+        bibliography::DataStructures.OrderedDict{String,Entry},
+        sorting_rule::Symbol = :key
+        )
+
+Sorts the bibliography in place.
+
+The sorting order can be set by specifying the `sorting_rule`. The sorting is
+implemented via `isless()` functions. For detailed insight have a look at the
+`isless()` implementation of Julia and `BibInternal.jl`.
+
+Supported symbols for `sorting_rule` are:
+- `:key` __(default)__: sort by bibliography keys e.g. BibTeX keys or `:id`
+- the sorting rules defined in [`sorting_rules`](@ref)
+
+!!! info "Note:"
+    The sorting is not following explicitly bibliographic alphabetizing
+    conventions. It follows standard comparator behaviour implied by the
+    implemented `isless()` functions (string comparators).
+"""
+function sort_bibliography!(
+    bibliography::DataStructures.OrderedDict{String,Entry},
+    sorting_rule::Symbol = :key
+    )
+# TODO: allow Union{Symbol,Vector{Symbol}} for a arbitrary custom sorting order
+#       this needs one additional type check and a check for allowed symbols in
+#       vector (check against fieldnames(Bibliography.BibInternal.Entry) )
+    if sorting_rule == :key
+        sort!(bibliography);
+    elseif sorting_rule in keys(sorting_rules)
+        sort!(bibliography,
+              lt = (a,b) -> recursive_isless(a,b,sorting_rules[sorting_rule]),
+              by = x -> bibliography[x]);
+    else
+        throw(ArgumentError("Unsupported sorting order!"));
+    end
+end
+
+"""
+    recursive_isless(a::Entry, b::Entry, fields::Tuple{Symbol},
+                     depth::Int = 0)
+
+Helper function for [`sort_bibliography!`](@ref).
+
+This function allows recursive checking if `a < b` with descending importance.
+The importance set for the comparison is defined by the argument `fields`. This
+argument is a tuple consisting of symbols denoting the fields of the data type
+`BibInternal.Entry`. The ordering implies the importance.
+
+The `depth` argument is purely for iterating/recursive purposes.
+"""
+function recursive_isless(a::Entry, b::Entry, fields::Vector{Symbol},
+                          depth::Int = 0)::Bool
+    i = depth + 1;
+    a_field = getfield(a,fields[i]);
+    b_field = getfield(b,fields[i]);
+
+    if (a_field == b_field)
+        if i == length(fields)
+            return false;
+        else
+            return recursive_isless(a,b,fields,i);
+        end
+    else
+        return a_field < b_field;
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,3 +34,5 @@ mybib2 = Bibliography.import_bibtex("demo_export.bib")
 
 rm("demo.bib")
 rm("demo_export.bib")
+
+include("test/sort_bibliography.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,4 +35,4 @@ mybib2 = Bibliography.import_bibtex("demo_export.bib")
 rm("demo.bib")
 rm("demo_export.bib")
 
-include("test/sort_bibliography.jl")
+include("sort_bibliography.jl")

--- a/test/sort_bibliography.jl
+++ b/test/sort_bibliography.jl
@@ -10,7 +10,7 @@ using Bibliography;
 #       github.com/plk/biblatex/blob/dev/testfiles/19-alphabetic-prefixed.pdf
 #       )
 
-testbib = Bibliography.import_bibtex("examples/test_sort.bib");
+testbib = Bibliography.import_bibtex("../examples/test_sort.bib");
 
 @testset "sort_bibliography! : Errors" begin
     @test_throws ArgumentError sort_bibliography!(testbib,:nnn);

--- a/test/sort_bibliography.jl
+++ b/test/sort_bibliography.jl
@@ -1,0 +1,69 @@
+module test_sort_bibliography
+
+using Test;
+using Bibliography;
+
+# TODO: replace this sorting testbib with a full example bibliography like
+#       https://github.com/plk/biblatex/tree/dev/bibtex/bib/biblatex
+#       in order to have a more real life testing scenario (the results
+#       could be adapted from
+#       github.com/plk/biblatex/blob/dev/testfiles/19-alphabetic-prefixed.pdf
+#       )
+
+testbib = Bibliography.import_bibtex("examples/test_sort.bib");
+
+@testset "sort_bibliography! : Errors" begin
+    @test_throws ArgumentError sort_bibliography!(testbib,:nnn);
+    @test_throws MethodError sort_bibliography!(testbib,"nyt");
+    @test_throws MethodError sort_bibliography!(testbib[testbib.keys[1]],:nyt);
+end
+
+result = ["1998BBaA1a";
+          "1998BBbA2a";
+          "2007JJaAbe";
+          "2007JJbAbe";
+          "2010JJBaAaa";
+          "2010JJBbAaa";
+          "2011JJBcAaa";
+          "2018DJaMad";
+          "2018DJaMae";
+          "SaA3a2010"]
+@testset "sort_bibliography! : Ordering: :key" begin
+    sort_bibliography!( testbib );
+    @test testbib.keys == result;
+    sort_bibliography!( testbib , :key );
+    @test testbib.keys == result;
+end
+
+result = ["2007JJbAbe";
+          "2007JJaAbe";
+          "2018DJaMae";
+          "2018DJaMad";
+          "2011JJBcAaa";
+          "2010JJBaAaa";
+          "2010JJBbAaa";
+          "SaA3a2010";
+          "1998BBbA2a";
+          "1998BBaA1a"];
+@testset "sort_bibliography! : Ordering: :nyt" begin
+    sort_bibliography!( testbib , :nyt );
+    @test testbib.keys == result;
+end
+
+
+result = ["2007JJbAbe";
+          "2007JJaAbe";
+          "2018DJaMae";
+          "2018DJaMad";
+          "2011JJBcAaa";
+          "2010JJBaAaa";
+          "2010JJBbAaa";
+          "SaA3a2010";
+          "1998BBaA1a";
+          "1998BBbA2a"];
+@testset "sort_bibliography! : Ordering: :nty" begin
+    sort_bibliography!( testbib , :nty );
+    @test testbib.keys == result;
+end
+
+end # module test_sort_bibliography


### PR DESCRIPTION
Simple sorting of bibliography.  #17
Sorting relies on correct implementation of `isless()` comparators of `BibInternal.Entry` field types.
The current sorting options are limited to name-year-title, name-title-year and BibTex/Entry.id ordering ([inspired by BibLaTex sorting options](https://ctan.org/pkg/biblatex)).
Further changes to make arbitrary sorting (custom field priorities) are possible.

Next steps for the next willing person:
- find a good `Entry` data type structure or implement subtypes and or have well defined fields in order to have well defined sorting behaviour (e.g. date sorting will not consider months as strings like `aug` or `may` or will accept months like 2021-13-13)
- add a good bibliography test file with known sorting results ([like the one of BibLaTex](https://github.com/plk/biblatex/tree/dev/bibtex/bib/biblatex)) in order to get battle tested results aligning with already established conventions (current sorting might not behave expected by conventions)
- implement alphabetizing rules aligning with conventions into the `isless()` functions of `BibInternal.jl` (English rules should be enough for now)
- for debugging reasons (for sorting) it would be nice to have [a nicer CLI output for the `Entry` type](https://docs.julialang.org/en/v1/manual/types/#man-custom-pretty-printing) similar to a bibliography output

If the additions are ok those lines could be added to the `README.md`
```
# Sort the bibliography by name, year, title
sort_bibliography!(bibliography,:nyt)
```