### PR TITLE
Add some tests, fix `masterthesis` -> `mastersthesis`

### DIFF
--- a/src/staticweb.jl
+++ b/src/staticweb.jl
@@ -44,18 +44,17 @@ function xnames(
         return xnames(entry, true)
     end
     entry_names = editors ? entry.editors : entry.authors
-    str = ""
 
-    start = true
-    for s in entry_names
-        str *= start ? "" : ", "
-        start = false
-        if names == :last
-            str *= s.particle * " " * s.last * " " * s.junior
-        else
-            str *= s.first * " " * s.middle * " " * s.particle * " " * s.last * " " * s.junior
-        end
+    if names == :last
+        parts = map(s -> [ s.particle, s.last, s.junior ], entry_names)
+    else
+        parts = map(s -> [ s.first, s.middle, s.particle, s.last, s.junior ], entry_names)
     end
+
+    entry_names = map(parts) do s
+        return join(filter(!isempty, s), " ")
+    end
+    str = join(entry_names, ", ")
     return replace(str, r"[\n\r ]+" => " ") # TODO: make it cleaner (is replace still necessary)
 end
 

--- a/src/staticweb.jl
+++ b/src/staticweb.jl
@@ -7,7 +7,7 @@ const type_to_label = Dict{String, String}([
     "incollection"    => "book section",
     "inproceedings"   => "conference",
     "manual"          => "manual",
-    "masterthesis"    => "master thesis",
+    "mastersthesis"   => "master's thesis",
     "misc"            => "other",
     "phdthesis"       => "doctoral thesis",
     "proceedings"     => "proceedings",
@@ -102,8 +102,8 @@ function xin(entry)
         str *= entry.in.organization
         str *= entry.in.address != "" ? ", $(entry.in.address)" : ""
         str *= ", " * entry.date.year
-    elseif entry.type ∈ ["masterthesis", "phdthesis"]
-        str *= entry.type == "masterthesis" ? "Master's" : "PhD"
+    elseif entry.type ∈ ["mastersthesis", "phdthesis"]
+        str *= entry.type == "mastersthesis" ? "Master's" : "PhD"
         str *= " thesis, " * entry.in.school
         str *= entry.in.address != "" ? ", $(entry.in.address)" : ""
         str *= ", " * entry.date.year

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,3 +37,4 @@ rm("demo.bib")
 rm("demo_export.bib")
 
 include("sort_bibliography.jl")
+include("staticweb.jl")

--- a/test/staticweb.jl
+++ b/test/staticweb.jl
@@ -1,0 +1,19 @@
+using ReferenceTests
+
+@testset "staticweb helpers" for file in ["test.bib"] #, "xampl.bib"] #, "ignace_ref.bib"]
+   bib = Bibliography.import_bibtex("../examples/$file")
+   result = ""
+   for (key, val) in bib
+     result *= """
+         key: $(key)
+           title: '$(Bibliography.xtitle(val))'
+           names: '$(Bibliography.xnames(val))'
+              in: '$(Bibliography.xin(val))'
+            year: '$(Bibliography.xyear(val))'
+            link: '$(Bibliography.xlink(val))'
+            file: '$(Bibliography.xfile(val))'
+
+         """
+   end
+   @test_reference "$file.txt" result
+end

--- a/test/test.bib.txt
+++ b/test/test.bib.txt
@@ -49,7 +49,7 @@ key: CitekeyManual
 key: CitekeyMastersthesis
   title: 'Spin structure of the nucleon in the asymptotic limit'
   names: 'Jian Tang'
-     in: ''
+     in: 'Master's thesis, Massachusetts Institute of Technology, Cambridge, MA, 1996.'
    year: '1996'
    link: ''
    file: 'files/CitekeyMastersthesis.pdf'

--- a/test/test.bib.txt
+++ b/test/test.bib.txt
@@ -1,0 +1,96 @@
+key: CiteEprint
+  title: 'Automatic Cost Function Learning with Interpretable Compositional Networks'
+  names: 'Florian Richoux, Jean-François Baffier'
+     in: 'arXiv:2002.09811 [cs.AI].'
+   year: '2020'
+   link: 'https://arxiv.org/abs/2002.09811'
+   file: 'files/CiteEprint.pdf'
+
+key: CitekeyArticle
+  title: 'The independence of the continuum hypothesis'
+  names: 'P. J. Cohen'
+     in: 'Proceedings of the National Academy of Sciences, 50(6), 1143--1148, 1963.'
+   year: '1963'
+   link: ''
+   file: 'files/CitekeyArticle.pdf'
+
+key: CitekeyBook
+  title: 'Classical mechanics: the theoretical minimum'
+  names: 'Leonard Susskind, George Hrabovsky'
+     in: 'Penguin Random House, New York, NY, 2014.'
+   year: '2014'
+   link: ''
+   file: 'files/CitekeyBook.pdf'
+
+key: CitekeyBooklet
+  title: 'Canoe tours in {S}weden'
+  names: 'Maria Swetla'
+     in: 'Distributed at the Stockholm Tourist Office, 2015.'
+   year: '2015'
+   link: ''
+   file: 'files/CitekeyBooklet.pdf'
+
+key: 
+  title: 'Pluto: The 'Other' Red Planet'
+  names: 'NASA'
+     in: '\url{https://www.nasa.gov/nh/pluto-the-other-red-planet}, 2015. Accessed: 2018-12-06.'
+   year: '2015'
+   link: ''
+   file: 'files/.pdf'
+
+key: CitekeyManual
+  title: '{R}: A Language and Environment for Statistical Computing'
+  names: 'R Core Team'
+     in: 'R Foundation for Statistical Computing, Vienna, Austria, 2018.'
+   year: '2018'
+   link: ''
+   file: 'files/CitekeyManual.pdf'
+
+key: CitekeyMastersthesis
+  title: 'Spin structure of the nucleon in the asymptotic limit'
+  names: 'Jian Tang'
+     in: ''
+   year: '1996'
+   link: ''
+   file: 'files/CitekeyMastersthesis.pdf'
+
+key: CitekeyPhdthesis
+  title: 'Relaxation Effects for Coupled Nuclear Spins'
+  names: 'Robert Charles Rempel'
+     in: 'PhD thesis, Stanford University, Stanford, CA, 1956.'
+   year: '1956'
+   link: ''
+   file: 'files/CitekeyPhdthesis.pdf'
+
+key: CitekeyProceedings
+  title: 'Proceedings of the 17th International Conference on Computation and Natural Computation, Fontainebleau, France'
+  names: 'Susan Stepney, Sergey Verlan'
+     in: 'Volume 10867 of Lecture Notes in Computer Science, Cham, Switzerland, 2018. Cham, Switzerland.'
+   year: '2018'
+   link: ''
+   file: 'files/CitekeyProceedings.pdf'
+
+key: CitekeyTechreport
+  title: '{W}asatch {S}olar {P}roject Final Report'
+  names: 'Vicki Bennett, Kate Bowman, Sarah Wright'
+     in: 'Technical Report DOE-SLC-6903-1, Salt Lake City Corporation, Salt Lake City, UT, 2018.'
+   year: '2018'
+   link: ''
+   file: 'files/CitekeyTechreport.pdf'
+
+key: CitekeyUnpublished
+  title: 'Evolution: a revised theory'
+  names: 'Mohinder Suresh'
+     in: 'Well, a note, 2006.'
+   year: '2006'
+   link: ''
+   file: 'files/CitekeyUnpublished.pdf'
+
+key: baffier2017experimental
+  title: 'Experimental Study of Compressed Stack Algorithms in Limited Memory Environments'
+  names: 'Jean-François Baffier, Yago Diez, Matias Korman'
+     in: 'arXiv:1706.04708 [cs.DS].'
+   year: '2017'
+   link: 'https://arxiv.org/abs/1706.04708'
+   file: 'files/baffier2017experimental.pdf'
+


### PR DESCRIPTION
This includes #23 (as first commit), then adds some tests using [ReferenceTests.jl](https://github.com/JuliaTesting/ReferenceTests.jl), and finally changes `masterthesis` -> `mastersthesis` (see https://github.com/Humans-of-Julia/BibInternal.jl/pull/9 for details).

The tests will fail for now, though, as the reference file assumes the fix from https://github.com/Humans-of-Julia/BibInternal.jl/pull/8. Once that had a new release, the tests can be rerun (and I can also rebase this PR if PR #23 is merged before it)

Note that `ReferenceTests.jl` makes it very convenient to update reference files: if run interactively, it will show diffs and offer you to update the reference file if the diffs are genuine.

It might be a good idea to also test `export_bibtex` with this (instead of printing its output to the user as part of the test suite). I can do that, but first wanted to hear what you think.