### PR TITLE
Fixing #30 and changing output behaviour.

### DIFF
--- a/src/staticweb.jl
+++ b/src/staticweb.jl
@@ -91,10 +91,10 @@ function xin(entry)
                  entry.in.publisher ,
                  entry.in.address ]
     elseif entry.type == "incollection"
-        # TODO: check if this new and the old format is/was correct, that "editors" seems out of place?
-        temp = [ "In " * xnames(entry, true) ,
+      # TODO: check if this new or the old format is/was correct, that "editors" seems out of place (and the title was switched with the names)?
+        temp = [ "In $(entry.booktitle)" ,
                  "editors" ,
-                 entry.booktitle ,
+                 xnames(entry, true) ,
                  entry.in.pages * ". " * entry.in.publisher , # TODO: conditional ". " if one of the strings is empty?
                  entry.in.address ,
                  entry.date.year ]

--- a/test/test.bib.txt
+++ b/test/test.bib.txt
@@ -89,7 +89,7 @@ key: CitekeyPhdthesis
 key: CitekeyProceedings
   title: 'Proceedings of the 17th International Conference on Computation and Natural Computation, Fontainebleau, France'
   names: 'Susan Stepney, Sergey Verlan'
-     in: 'Volume 10867 of Lecture Notes in Computer Science, Cham, Switzerland, 2018. Cham, Switzerland.'
+     in: 'Volume 10867 of Lecture Notes in Computer Science, Cham, Switzerland, 2018. Springer.'
    year: '2018'
    link: ''
    file: 'files/CitekeyProceedings.pdf'

--- a/test/test.bib.txt
+++ b/test/test.bib.txt
@@ -41,7 +41,7 @@ key: CitekeyInbook
 key: CitekeyIncollection
   title: 'Flow Cytometry: The Glass Is Half Full'
   names: 'Howard M. Shapiro'
-     in: 'In Teresa S. Hawley, Robert G. Hawley, editors, Flow Cytometry Protocols, 1--10. Springer, New York, NY, 2018.'
+     in: 'In Flow Cytometry Protocols, editors, Teresa S. Hawley, Robert G. Hawley, 1--10. Springer, New York, NY, 2018.'
    year: '2018'
    link: ''
    file: 'files/CitekeyIncollection.pdf'


### PR DESCRIPTION
Fixing #30 by changing the string concatenation of `xin()`.
Changed also the behaviour of `proceedings` and `incollection` output as there where some logical bugs (please check and correct if necessary).
```diff
diff --git a/test/test.bib.txt b/test/test.bib.txt
index 6e25cc8..2a47864 100644
--- a/test/test.bib.txt
+++ b/test/test.bib.txt
@@ -89,7 +89,7 @@ key: CitekeyPhdthesis
 key: CitekeyProceedings
   title: 'Proceedings of the 17th International Conference on Computation and Natural Computation, Fontainebleau, France'
   names: 'Susan Stepney, Sergey Verlan'
-     in: 'Volume 10867 of Lecture Notes in Computer Science, Cham, Switzerland, 2018. Cham, Switzerland.'
+     in: 'Volume 10867 of Lecture Notes in Computer Science, Cham, Switzerland, 2018. Springer.'
    year: '2018'
    link: ''
    file: 'files/CitekeyProceedings.pdf
@@ -41,7 +41,7 @@ key: CitekeyInbook
 key: CitekeyIncollection
   title: 'Flow Cytometry: The Glass Is Half Full'
   names: 'Howard M. Shapiro'
-     in: 'In Teresa S. Hawley, Robert G. Hawley, editors, Flow Cytometry Protocols, 1--10. Springer, New York, NY, 2018.'
+     in: 'In Flow Cytometry Protocols, editors, Teresa S. Hawley, Robert G. Hawley, 1--10. Springer, New York, NY, 2018.'
    year: '2018'
    link: ''
    file: 'files/CitekeyIncollection.pdf'
```
This should be enough to close the issue as the arXiv links have no direct field representation for `xlink()`.