### PR TITLE
Add FileIO interface for .bib files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BibInternal = "2027ae74-3657-4b95-ae00-e2f7d55c3e64"
 BibParser = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]

--- a/src/Bibliography.jl
+++ b/src/Bibliography.jl
@@ -11,6 +11,7 @@ import BibParser: BibTeX, CFF
 # Others
 import DataStructures
 import DataStructures.OrderedSet
+import FileIO
 
 export export_bibtex, import_bibtex
 export export_cff, import_cff
@@ -24,6 +25,7 @@ include("bibtex.jl")
 include("cff.jl")
 include("csl.jl")
 include("staticweb.jl")
+include("fileio.jl")
 
 """
     export_bibtex(target, bibliography)

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,0 +1,30 @@
+"""
+    fileio_load(file; check)
+    fileio_load(stream; check)
+
+The FileIO interface to import a BibTeX file or parse a BibTeX string and convert it to the internal bibliography format.
+The `check` keyword argument can be set to `:none` (or `nothing`), `:warn`, or `:error` to raise appropriate logs.
+"""
+function fileio_load(file::FileIO.File{FileIO.format"BIB"}; check = :error)
+    BibParser.parse_file(file.filename; check)
+end
+
+function fileio_load(stream::FileIO.Stream{FileIO.format"BIB"}; check = :error)
+    BibParser.parse_entry(read(stream, String); check)
+end
+
+"""
+    fileio_save(file, data)
+    fileio_save(stream, data)
+
+Export a bibliography as a BibTeX string to a file or stream.
+"""
+function fileio_save(file::FileIO.File{FileIO.format"BIB"}, data)
+    open(file, "w") do f
+        write(f, export_bibtex(data))
+    end
+end
+
+function fileio_save(stream::FileIO.Stream{FileIO.format"BIB"}, data)
+    write(stream, export_bibtex(data))
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Bibliography
+using FileIO
 using Test
 using ReferenceTests
 
@@ -44,3 +45,4 @@ rm("demo_export.bib")
 include("sort_bibliography.jl")
 include("staticweb.jl")
 include("cff.jl")
+include("test-fileio.jl")

--- a/test/test-fileio.jl
+++ b/test/test-fileio.jl
@@ -1,0 +1,28 @@
+@testset "FileIO interface functions." begin
+    F = FileIO.File{FileIO.format"BIB"}
+    S = FileIO.Stream{FileIO.format"BIB"}
+
+    # Load, export and reload as file.
+    let
+        bib = Bibliography.fileio_load(F("test.bib"))
+        Bibliography.fileio_save(F("test-fileio.bib"), bib)
+        bib2 = Bibliography.fileio_load(F("test-fileio.bib"))
+        @test_broken bib == bib2
+        rm("test-fileio.bib")
+    end
+
+    # Load, export and reload as stream.
+    let
+        bib = open("test.bib") do f
+            Bibliography.fileio_load(S(f))
+        end
+        open("test-fileio.bib", "w") do f
+            Bibliography.fileio_save(S(f), bib)
+        end
+        bib2 = open("test-fileio.bib") do f
+            Bibliography.fileio_load(S(f))
+        end
+        @test_broken bib == bib2
+        rm("test-fileio.bib")
+    end
+end


### PR DESCRIPTION
Thank you for making this library!

Currently, importing from bib files or strings uses the same interface `import_bibtex`, but it is having an issue for me: For longer strings, `isfile` function fails due to `ENAMETOOLONG` error. While this issue can be resolved easily with ad-hoc solutions, I am thinking that maybe utilizing https://github.com/JuliaIO/FileIO.jl package could make a unified IO interface.

This PR is an attempt to implement interfaces required by FileIO for .bib files. If you think this is good, after it's merged, I will create a PR on the FileIO side to register this package for .bib files. I think it also serves as a good template to implement IO interfaces for other bibliography formats as well, such as .cff.

I added some tests to show that the functions actually work okay. The only issue is that I tried to validate bib contents by comparing the bib entries for equality, but even two consecutive reads of the same file do not produce entries that compare equal. However, I think this is a different issue and might better be discussed in `BibInternal.jl`.