### PR TITLE
Add isbn and issn fields to in_to_bibtex method

### DIFF
--- a/src/bibtex.jl
+++ b/src/bibtex.jl
@@ -103,6 +103,8 @@ function in_to_bibtex!(fields, in_)
     fields["chapter"] = in_.chapter
     fields["edition"] = in_.edition
     fields["institution"] = in_.institution
+    fields["isbn"] = in_.isbn
+    fields["issn"] = in_.issn
     fields["journal"] = in_.journal
     fields["number"] = in_.number
     fields["organization"] = in_.organization


### PR DESCRIPTION
This contribution adds the `isbn` and `issn` fields to `in_to_bibtex()` method.